### PR TITLE
Move static site hosting to GitHub Pages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,11 +1,7 @@
 name: CD
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    branches: [main]
-    types:
-      - completed
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -14,7 +10,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ false }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,60 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build static site
+        env:
+          NEXT_PUBLIC_BASE_PATH: /tla-by-example
+        run: npm run build
+
+      - name: Disable Jekyll processing
+        run: touch ./out/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
 const nextConfig = {
   output: "export",
+  trailingSlash: true,
+  basePath,
+  assetPrefix: basePath || undefined,
 };
 
 export default nextConfig;


### PR DESCRIPTION
## PoC

https://lemmster.de/tla-by-example/

## Summary

- Migrate deployment from VPS rsync to GitHub Pages via GitHub Actions.
- Configure Next.js static export for project-site hosting at `/tla-by-example`.
- Disable the legacy VPS deployment workflow.

## Changes

- Added a Pages deployment workflow in `.github/workflows/pages.yml` using:
  - `actions/configure-pages`
  - `actions/upload-pages-artifact`
  - `actions/deploy-pages`
- Updated `next.config.mjs` to support GitHub Pages project-path hosting:
  - `basePath` from `NEXT_PUBLIC_BASE_PATH`
  - `assetPrefix` aligned with `basePath`
  - `trailingSlash: true` for static route compatibility
- Disabled legacy VPS deploy in `.github/workflows/cd.yml` (manual-only and non-running).

## Notes

- Some runtime content will continue to be fetched from `cjrtnc.leaningtech.com` (e.g. CheerpJ loader/runtime) due to [Leaning Technologies licensing/distribution requirements](https://cheerpj.com/docs/licensing#cheerpj-community-license).
- Repository-hosted static assets (including exported app pages and TLC JAR artifacts) are still served from GitHub Pages.
